### PR TITLE
Fix offline player check

### DIFF
--- a/src/main/java/net/nperkins/stablemaster/commands/subcommands/AddRider.java
+++ b/src/main/java/net/nperkins/stablemaster/commands/subcommands/AddRider.java
@@ -26,7 +26,7 @@ public class AddRider implements SubHandler {
                         @Override
                         public void run() {
                             OfflinePlayer rider = plugin.getServer().getOfflinePlayer(riderName);
-                            if (rider != null) {
+                            if (rider != null && rider.hasPlayedBefore()) {
                                 plugin.addRiderQueue.put((Player) sender, rider);
                                 sender.sendMessage(StableMaster.playerMessage("Punch your horse."));
                             } else {

--- a/src/main/java/net/nperkins/stablemaster/commands/subcommands/DelRider.java
+++ b/src/main/java/net/nperkins/stablemaster/commands/subcommands/DelRider.java
@@ -26,7 +26,7 @@ public class DelRider implements SubHandler {
                         @Override
                         public void run() {
                             OfflinePlayer rider = plugin.getServer().getOfflinePlayer(riderName);
-                            if (rider != null) {
+                            if (rider != null && rider.hasPlayedBefore()) {
                                 plugin.delRiderQueue.put((Player) sender, rider);
                                 sender.sendMessage(StableMaster.playerMessage("Punch your horse."));
                             } else {

--- a/src/main/java/net/nperkins/stablemaster/commands/subcommands/Give.java
+++ b/src/main/java/net/nperkins/stablemaster/commands/subcommands/Give.java
@@ -25,7 +25,7 @@ public class Give implements SubHandler {
                         @Override
                         public void run() {
                             OfflinePlayer rider = plugin.getServer().getOfflinePlayer(ownerName);
-                            if (rider != null) {
+                            if (rider != null && rider.hasPlayedBefore()) {
                                 plugin.giveQueue.put((Player) sender, rider);
                                 sender.sendMessage(StableMaster.playerMessage("Punch your horse."));
                             } else {


### PR DESCRIPTION
Prevents players from giving horses to usernames with typos; getOfflinePlayer will return a value even if no player is found.
